### PR TITLE
Changes condition, so FeedUpdateOptions.index can be 0

### DIFF
--- a/src/feed/index.ts
+++ b/src/feed/index.ts
@@ -125,7 +125,7 @@ export function makeFeedReader(
     owner,
     topic,
     async download(options?: FeedUpdateOptions): Promise<FetchFeedUpdateResponse> {
-      if (!options?.index) {
+      if (!options?.index && options?.index !== 0 {
         return fetchLatestFeedUpdate(requestOptions, owner, topic, { ...options, type })
       }
 


### PR DESCRIPTION
Currently, if one tries to download index 0, like so:

`await ourReader.download({ index: 0 });`

instead of downloading index 0, it will download the last index, because 0 is falsy value in JavaScript. I think we need to check if the index is 0, because in that case, we shouldn't go into the if-condition.